### PR TITLE
Fixed reduced duration of output video bug + scale passed as timestep bug.

### DIFF
--- a/inference_video.py
+++ b/inference_video.py
@@ -108,7 +108,7 @@ if not args.video is None:
     videoCapture.release()
     if args.fps is None:
         fpsNotAssigned = True
-        args.fps = fps * args.multi
+        args.fps = fps * (args.multi - 1)
     else:
         fpsNotAssigned = False
     videogen = skvideo.io.vreader(args.video)
@@ -241,7 +241,7 @@ while True:
         
     if ssim < 0.2:
         output = []
-        for i in range(args.multi):
+        for i in range(args.multi - 1):
             output.append(I0)
         '''
         output = []
@@ -253,7 +253,7 @@ while True:
             output.append(torch.from_numpy(np.transpose((cv2.addWeighted(frame[:, :, ::-1], alpha, lastframe[:, :, ::-1], beta, 0)[:, :, ::-1].copy()), (2,0,1))).to(device, non_blocking=True).unsqueeze(0).float() / 255.)
         '''
     else:
-        output = make_inference(I0, I1, args.multi)
+        output = make_inference(I0, I1, args.multi - 1)
 
     if args.montage:
         write_buffer.put(np.concatenate((lastframe, lastframe), 1))

--- a/inference_video.py
+++ b/inference_video.py
@@ -241,7 +241,7 @@ while True:
         
     if ssim < 0.2:
         output = []
-        for i in range(args.multi - 1):
+        for i in range(args.multi):
             output.append(I0)
         '''
         output = []
@@ -253,7 +253,7 @@ while True:
             output.append(torch.from_numpy(np.transpose((cv2.addWeighted(frame[:, :, ::-1], alpha, lastframe[:, :, ::-1], beta, 0)[:, :, ::-1].copy()), (2,0,1))).to(device, non_blocking=True).unsqueeze(0).float() / 255.)
         '''
     else:
-        output = make_inference(I0, I1, args.multi-1)
+        output = make_inference(I0, I1, args.multi)
 
     if args.montage:
         write_buffer.put(np.concatenate((lastframe, lastframe), 1))

--- a/inference_video.py
+++ b/inference_video.py
@@ -234,7 +234,7 @@ while True:
             temp = frame
         I1 = torch.from_numpy(np.transpose(frame, (2,0,1))).to(device, non_blocking=True).unsqueeze(0).float() / 255.
         I1 = pad_image(I1)
-        I1 = model.inference(I0, I1, args.scale)
+        I1 = model.inference(I0, I1, scale=args.scale)
         I1_small = F.interpolate(I1, (32, 32), mode='bilinear', align_corners=False)
         ssim = ssim_matlab(I0_small[:, :3], I1_small[:, :3])
         frame = (I1[0] * 255).byte().cpu().numpy().transpose(1, 2, 0)[:h, :w]


### PR DESCRIPTION
The calculation of output video fps was getting performed on the given multiplier, while the inference used a value of (multiplier - 1), causing the video writer to incorrectly interpreting the output video and highly reduces the duration.

Also in the case of ssim > 0.996, the inference gets the scale passed right away without specifying the name of the argument, causing the scale value getting passed as the timestep value, which is a huge problem. 

I am not sure how such a big issue is left here...

I have written a full refactor for the video inference script, correcting all the PEP violations and segregating the code into multiple classes for higher readability, I plan to post it here after #23 gets merged.